### PR TITLE
USB Profile Support

### DIFF
--- a/client_scrapers/config.example.php
+++ b/client_scrapers/config.example.php
@@ -10,6 +10,7 @@ $cacheDir = "C:/Users/[USER]/AppData/Roaming/StepMania 5.1/Cache/Songs";
 //SM5: "[AppData]/Roaming/StepMania 5/Save"
 //SM5.1: "[AppData]/Roaming/StepMania 5.1/Save"
 //SM5.3 (OutFox) or portable installations: "[SM5]/Save"
+//If using USB Profile, please configure the $profileDir to point at your drive/share location for the USB Drive
 $saveDir = "C:/Users/[USER]/AppData/Roaming/StepMania 5.1/Save";
 $profileDir = $saveDir."/LocalProfiles";
 
@@ -37,5 +38,9 @@ $security_key = "any-secret-here";
 //Set this to TRUE if you are running the request system on a separate machine that has no realtime access to the StepMania files
 //For a description of this operation mode, review the main README.
 $offlineMode = FALSE;
+
+//USB Profile Mode
+//Set this to True if you are using a USB profile as your profile location 
+$USBProfile = FALSE;
 
 ?>

--- a/client_scrapers/config.example.php
+++ b/client_scrapers/config.example.php
@@ -43,4 +43,7 @@ $offlineMode = FALSE;
 //Set this to True if you are using a USB profile as your profile location 
 $USBProfile = FALSE;
 
+//This should match the value in your Preferences.ini file if you are using USBProfiles
+$MemoryCardProfileSubdir = "StepMania 5.3";
+
 ?>

--- a/client_scrapers/scrape stats.bat
+++ b/client_scrapers/scrape stats.bat
@@ -4,5 +4,7 @@ cd "C:\php"
 cls
 ::you must add profile IDs and the optional "-auto" argument for this script to run
 ::example:  php.exe "%~dp0scrape_stats.php" -auto 00000000
+::If using USBProfiles, the location should match what is in your Preferences.ini -> MemoryCardProfileSubdir=StepMania 5.3
+::example:  php.exe "%~dp0scrape_stats.php" -auto "StepMania 5.3"
 php.exe "%~dp0scrape_stats.php"
 pause

--- a/client_scrapers/scrape_stats.php
+++ b/client_scrapers/scrape_stats.php
@@ -49,6 +49,8 @@ if (php_sapi_name() == "cli") {
 				$profileIDs[] = $arg;
 			}elseif ($arg == "-auto"){
 				$autoRun = FALSE;
+			}elseif ($arg = $MemoryCardProfileSubdir){
+				$profileIDs[] = $arg;
 			}
 		}
 		if($USBProfile){

--- a/client_scrapers/scrape_stats.php
+++ b/client_scrapers/scrape_stats.php
@@ -27,6 +27,12 @@ echo "*********************************************************" . PHP_EOL;
 echo "" . PHP_EOL;
 
 //Config
+if(file_exists(__DIR__."/config.php") && is_file(__DIR__."/config.php")){
+	require ('config.php');
+}else{
+	wh_log("config.php file not found! You must configure these scripts before running. You can find an example config.php file at config.example.php.");
+	die("config.php file not found! You must configure these scripts before running. You can find an example config.php file at config.example.php.".PHP_EOL);
+}
 
 if (php_sapi_name() == "cli") {
 	// In cli-mode
@@ -45,7 +51,9 @@ if (php_sapi_name() == "cli") {
 				$autoRun = FALSE;
 			}
 		}
-		if (empty($profileIDs)){die("Please specify at least 1 profile ID! Usage: scrape_stats.php [-auto] 00000000");}
+		if($USBProfile){
+			if (empty($profileIDs)){die("Please specify at least 1 profile ID! Usage: scrape_stats.php [-auto] 00000000");}
+		}
 	}else{
 		die("No arguments! Usage: scrape_stats.php [-auto] 00000000");
 	}
@@ -77,13 +85,6 @@ if (php_sapi_name() == "cli") {
 			}
 		}
 	}
-}
-
-if(file_exists(__DIR__."/config.php") && is_file(__DIR__."/config.php")){
-	require ('config.php');
-}else{
-	wh_log("config.php file not found! You must configure these scripts before running. You can find an example config.php file at config.example.php.");
-	die("config.php file not found! You must configure these scripts before running. You can find an example config.php file at config.example.php.".PHP_EOL);
 }
 
 //


### PR DESCRIPTION
Some simple changes to make USB Profiles possible. We may wish for some additional checks later but we can make an assumption that if someone has USB Profiles setup and working, they are informed on how it should function.

Changes made include a rearrangement of the initialization process so that we read the config settings earlier in order to determine the check of profile arrays is necessary or not. Additionally, we need to add the actual check bypass if necessary. Once the check is bypassed and the batch file is setup correctly, as outlined in the comments, USB Profiles work with all other existing code.